### PR TITLE
Create timestamped log dir

### DIFF
--- a/include/glim_ros/utils.hpp
+++ b/include/glim_ros/utils.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <filesystem>
+#include <chrono>
+#include <iomanip>
+#include <sstream>
+#include <stdexcept>
+
+namespace glim_ros {
+
+static std::string create_timestamped_dir(const std::string& base_path) {
+
+    // Remove trailing slash if present
+    std::string clean_base = base_path;
+    if (!clean_base.empty() && clean_base.back() == '/') {
+        clean_base.pop_back();
+    }
+
+    // Get current time
+    auto now = std::chrono::system_clock::now();
+    std::time_t now_c = std::chrono::system_clock::to_time_t(now);
+    std::tm tm;
+    localtime_r(&now_c, &tm);
+    std::ostringstream oss;
+    oss << clean_base << "/glim_dump_"
+        << std::put_time(&tm, "%Y_%m_%d_%H_%M_%S");
+
+    return oss.str();
+}
+
+} // namespace glim_ros
+
+

--- a/src/glim_rosbag.cpp
+++ b/src/glim_rosbag.cpp
@@ -15,6 +15,7 @@
 #include <glim/util/extension_module_ros2.hpp>
 #include <glim_ros/glim_ros.hpp>
 #include <glim_ros/ros_compatibility.hpp>
+#include <glim_ros/utils.hpp>
 
 class SpeedCounter {
 public:
@@ -95,6 +96,16 @@ int main(int argc, char** argv) {
   for (const auto& bag_filename : bag_filenames) {
     spdlog::info("- {}", bag_filename);
   }
+
+  // Get, validate and log dump path
+  std::string dump_path = "/tmp/dump";
+  glim->declare_parameter<std::string>("dump_path", dump_path);
+  glim->get_parameter<std::string>("dump_path", dump_path);
+  std::string dump_path_timestamped;
+  dump_path_timestamped = glim_ros::create_timestamped_dir(dump_path);
+    
+  spdlog::info("dump_path: {}", dump_path);
+  spdlog::info("dump_path_timestamped: {}", dump_path_timestamped);
 
   // Playback range settings
   double delay = 0.0;
@@ -290,10 +301,6 @@ int main(int argc, char** argv) {
   glim->declare_parameter<bool>("auto_quit", auto_quit);
   glim->get_parameter<bool>("auto_quit", auto_quit);
 
-  std::string dump_path = "/tmp/dump";
-  glim->declare_parameter<std::string>("dump_path", dump_path);
-  glim->get_parameter<std::string>("dump_path", dump_path);
-
   for (const auto& bag_filename : bag_filenames) {
     if (!read_bag(bag_filename)) {
       auto_quit = true;
@@ -306,7 +313,7 @@ int main(int argc, char** argv) {
   }
 
   glim->wait(auto_quit);
-  glim->save(dump_path);
+  glim->save(dump_path_timestamped);
 
   return 0;
 }

--- a/src/glim_rosnode.cpp
+++ b/src/glim_rosnode.cpp
@@ -5,6 +5,7 @@
 #include <glim_ros/glim_ros.hpp>
 #include <glim/util/config.hpp>
 #include <glim/util/extension_module_ros2.hpp>
+#include <glim_ros/utils.hpp>
 
 int main(int argc, char** argv) {
   rclcpp::init(argc, argv);
@@ -13,15 +14,21 @@ int main(int argc, char** argv) {
 
   auto glim = std::make_shared<glim::GlimROS>(options);
 
-  rclcpp::spin(glim);
-  rclcpp::shutdown();
-
+  // Get, validate and log dump path
   std::string dump_path = "/tmp/dump";
   glim->declare_parameter<std::string>("dump_path", dump_path);
   glim->get_parameter<std::string>("dump_path", dump_path);
+  std::string dump_path_timestamped;
+  dump_path_timestamped = glim_ros::create_timestamped_dir(dump_path);
+  spdlog::info("dump_path: {}", dump_path);
+  spdlog::info("dump_path_timestamped: {}", dump_path_timestamped);
+
+  rclcpp::spin(glim);
+
+  rclcpp::shutdown();
 
   glim->wait();
-  glim->save(dump_path);
+  glim->save(dump_path_timestamped);
 
   return 0;
 }


### PR DESCRIPTION
Allows to set a log base dir as parameter.
All glim logs (including map) will be dumped into a timestamped folder in the specified dir.